### PR TITLE
(#12) modified the generic arguments

### DIFF
--- a/src/MediatR.LightCore/MediatR.LightCore.Tests/Sample/ExceptionHandler/ExceptionsHandlers.cs
+++ b/src/MediatR.LightCore/MediatR.LightCore.Tests/Sample/ExceptionHandler/ExceptionsHandlers.cs
@@ -1,11 +1,19 @@
 using MediatR.Pipeline;
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace MediatR.Examples.ExceptionHandler
 {
+    public class GenericExceptionAction<TRequest> : RequestExceptionAction<TRequest>
+    {
+        protected override void Execute(TRequest request, Exception exception)
+        {
+        }
+    }
+
     public class CommonExceptionHandler : AsyncRequestExceptionHandler<PingResource, Pong>
     {
         private readonly TextWriter _writer;

--- a/src/MediatR.LightCore/MediatR.LightCore/Register.cs
+++ b/src/MediatR.LightCore/MediatR.LightCore/Register.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MediatR.Pipeline;
 
 namespace MediatR.LightCore
 {
@@ -80,12 +81,13 @@ namespace MediatR.LightCore
                 for (int i = 0; i < typeGenericArguments.Length; i++)
                 {
                     isAssignable &= typeGenericArguments[i].BaseType.IsAssignableFrom(genericArgument[i]);
+                    typeGenericArguments[i] = genericArgument[i];
                 }
                 if (!isAssignable) { return; }
                 var regClass = type;
                 if (type.IsGenericType)
                 {
-                    regClass = type.MakeGenericType(genericArgument);
+                    regClass = type.MakeGenericType(typeGenericArguments);
                 }
                 containerBuilder.Register(regType, regClass);
                 count++;


### PR DESCRIPTION
To match the arguments of the implementing class instead to that of the interface.

The unit test does not directly reproduce the code from #12 but rather registers an `RequestExceptionAction`. Registering an `IRequestExceptionHandler<,>` or `IRequestExceptionHandler<,,>` leads directly to #13.

Fixes #12  