### PR TITLE
(maint) fixed GH-Actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ windows-2019, ubuntu-18.04, macos-10.15 ]
 
     steps:
       - name: Checkout the repository 


### PR DESCRIPTION
by pinning virtual machines to the "working" ones.
Specifically , ubuntu-18.04 and macos-10.15